### PR TITLE
Handled Undefined Cookies

### DIFF
--- a/src/modules/Common/ModuleContainer.jsx
+++ b/src/modules/Common/ModuleContainer.jsx
@@ -14,8 +14,13 @@ class ModuleContainer extends Component {
     this.moduleCookie = new Cookies();
     this.state = {
       id: this.props.id,
-      currentModule: this.moduleCookie.get(`${this.props.id}-choice`)
+      currentModule: this.checkCookie()
     };
+  }
+
+  checkCookie = () => {
+    let cookie = this.moduleCookie.get(`${this.props.id}-choice`);
+    return typeof cookie !== "undefined" ? cookie : "proto-module";
   }
 
   onChange = (e) => {


### PR DESCRIPTION
If a cookie doesn't exist, it returns undefined if the browser checks
for it. I didn't account for that, now we have a function that handles
the undefined value, and has the window default to the proto-module.